### PR TITLE
Add nvidia symvers override

### DIFF
--- a/_container_build.sh
+++ b/_container_build.sh
@@ -13,7 +13,7 @@ while :; do
   shift
 done
 
-
+export IGNORE_MISSING_MODULE_SYMVERS=1
 VERSION=$1
 echo Building ${VERSION}
 


### PR DESCRIPTION
Using virtualbox I was unable to build the kernel modules without this override as I did not have the required symbols file.